### PR TITLE
SM fixes and some genetics access changes

### DIFF
--- a/_maps/map_files/LimaStation/Lima.dmm
+++ b/_maps/map_files/LimaStation/Lima.dmm
@@ -4584,7 +4584,7 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/trinary/filter/flipped{
+/obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
 	dir = 4
 	},
 /turf/open/floor/engine,
@@ -4602,8 +4602,9 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "akR" = (
-/obj/structure/cable,
 /obj/effect/landmark/start/station_engineer,
+/obj/structure/cable/layer1,
+/obj/structure/cable,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "akS" = (
@@ -8752,6 +8753,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "auE" = (
@@ -8764,6 +8766,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "auF" = (
@@ -8899,10 +8902,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
 	},
+/obj/structure/cable/layer1,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "auX" = (
@@ -8911,10 +8914,10 @@
 	req_access_txt = "10"
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 8
 	},
+/obj/structure/cable/layer1,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "auY" = (
@@ -8928,6 +8931,8 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
 	},
+/obj/structure/cable/layer1,
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "ava" = (
@@ -8954,10 +8959,10 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "avc" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
 	},
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "avd" = (
@@ -9008,6 +9013,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable/layer1,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "avj" = (
@@ -9139,6 +9145,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable/layer1,
 /turf/open/floor/plasteel/showroomfloor,
 /area/engine/engineering)
 "avy" = (
@@ -9197,10 +9204,12 @@
 /area/hallway/primary/port)
 "avE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable/layer1,
 /turf/open/floor/plasteel/showroomfloor,
 /area/engine/engineering)
 "avF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable,
 /turf/open/floor/plasteel/showroomfloor,
 /area/engine/engineering)
 "avG" = (
@@ -9228,6 +9237,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
+/obj/structure/cable/layer1,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "avK" = (
@@ -9261,14 +9271,14 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "avO" = (
-/obj/structure/cable,
-/obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/landmark/event_spawn,
+/obj/structure/cable/layer1,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "avP" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable/layer1,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "avQ" = (
@@ -9291,6 +9301,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
+/obj/structure/cable/layer1,
 /turf/open/floor/plasteel/showroomfloor,
 /area/engine/engineering)
 "avU" = (
@@ -9344,6 +9355,7 @@
 "awb" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable/layer1,
 /turf/open/floor/plasteel/showroomfloor,
 /area/engine/engineering)
 "awc" = (
@@ -9368,6 +9380,7 @@
 /area/engine/engineering)
 "awf" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/structure/cable/layer1,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "awg" = (
@@ -10412,14 +10425,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"ayv" = (
-/obj/structure/closet/wardrobe/engineering_yellow,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "ayw" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
@@ -10452,17 +10457,17 @@
 	req_access_txt = "10"
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/obj/structure/cable/layer1,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "ayB" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
+/obj/structure/cable/layer1,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "ayC" = (
@@ -14151,8 +14156,7 @@
 "aHT" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/door/airlock/medical{
-	name = "Viewing Room";
-	req_access_txt = null
+	name = "Viewing Room"
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/medical/medbay/central)
@@ -14998,7 +15002,7 @@
 "aJD" = (
 /obj/machinery/door/airlock/research/glass{
 	name = "Genetics Research";
-	req_access_txt = "9;40"
+	req_one_access_txt = "9;40"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/white,
@@ -19359,7 +19363,7 @@
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
 "aTP" = (
-/obj/machinery/atmospherics/components/trinary/filter/flipped{
+/obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
 	dir = 4
 	},
 /turf/open/floor/engine,
@@ -19386,7 +19390,7 @@
 "aTT" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/engine_waste,
 /turf/open/floor/plating/airless,
-/area/space/nearstation)
+/area/engine/engineering)
 "aTU" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
@@ -19480,6 +19484,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
 	},
+/obj/machinery/meter,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "aUi" = (
@@ -19724,8 +19729,8 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "aUR" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/obj/structure/cable/layer1,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aUS" = (
@@ -19972,6 +19977,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/purple/visible,
+/obj/machinery/meter,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "aVE" = (
@@ -20850,6 +20856,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/purple/visible,
+/obj/machinery/meter,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "aYd" = (
@@ -21028,19 +21035,21 @@
 "aYG" = (
 /obj/structure/window/plasma/reinforced,
 /obj/machinery/power/rad_collector/anchored,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 6
 	},
+/obj/structure/cable/layer1,
+/obj/structure/cable_bridge,
 /turf/open/floor/engine,
 /area/engine/supermatter)
 "aYH" = (
 /obj/structure/window/plasma/reinforced,
 /obj/machinery/power/rad_collector/anchored,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 1
 	},
+/obj/structure/cable/layer1,
+/obj/structure/cable_bridge,
 /turf/open/floor/engine,
 /area/engine/supermatter)
 "aYI" = (
@@ -21093,10 +21102,11 @@
 	dir = 1
 	},
 /obj/machinery/power/rad_collector/anchored,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 5
 	},
+/obj/structure/cable/layer1,
+/obj/structure/cable_bridge,
 /turf/open/floor/engine,
 /area/engine/supermatter)
 "aYP" = (
@@ -21104,8 +21114,9 @@
 	dir = 1
 	},
 /obj/machinery/power/rad_collector/anchored,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/general/visible,
+/obj/structure/cable/layer1,
+/obj/structure/cable_bridge,
 /turf/open/floor/engine,
 /area/engine/supermatter)
 "aYQ" = (
@@ -21237,18 +21248,18 @@
 /area/medical/surgery/room_b)
 "aZh" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 9
 	},
+/obj/structure/cable/layer1,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "aZi" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/structure/cable/layer1,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "aZj" = (
@@ -21300,6 +21311,7 @@
 /obj/machinery/atmospherics/pipe/manifold/green/visible{
 	dir = 4
 	},
+/obj/machinery/meter,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "aZq" = (
@@ -21320,6 +21332,7 @@
 /area/engine/engineering)
 "aZs" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
+/obj/machinery/meter,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aZt" = (
@@ -21344,6 +21357,7 @@
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
 	dir = 4
 	},
+/obj/machinery/meter,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "aZw" = (
@@ -21399,6 +21413,7 @@
 /obj/machinery/atmospherics/pipe/manifold/orange/visible{
 	dir = 8
 	},
+/obj/machinery/meter,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "aZC" = (
@@ -21757,10 +21772,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/obj/structure/cable/layer1,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "baB" = (
@@ -21770,10 +21785,10 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/obj/structure/cable/layer1,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "baC" = (
@@ -21790,19 +21805,19 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/obj/structure/cable/layer1,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "baE" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/structure/cable/layer1,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "baF" = (
@@ -23136,7 +23151,7 @@
 "bdJ" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Medbay Maintenance";
-	req_access_txt = "5"
+	req_one_access_txt = "5;9"
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -24125,7 +24140,7 @@
 "bfC" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Genetics Maintenance";
-	req_access_txt = "9;40"
+	req_one_access_txt = "9;40"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
@@ -25559,7 +25574,7 @@
 /area/maintenance/aft)
 "brA" = (
 /obj/effect/turf_decal/stripes,
-/obj/structure/cable,
+/obj/structure/cable/layer1,
 /turf/open/floor/engine,
 /area/engine/supermatter)
 "brX" = (
@@ -25721,6 +25736,14 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/security/prison)
+"bCo" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "SupermatterExternal";
+	name = "radiation shutters"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/plating,
+/area/engine/engineering)
 "bCB" = (
 /obj/machinery/door/airlock/research{
 	name = "Closet";
@@ -25828,6 +25851,13 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
+"bKm" = (
+/obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
+	dir = 4;
+	filter_type = "n2"
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "bKw" = (
 /obj/docking_port/stationary/random{
 	dir = 4;
@@ -25929,6 +25959,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
+"bTT" = (
+/obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "bUA" = (
 /turf/closed/wall/r_wall,
 /area/medical/genetics)
@@ -26201,6 +26237,17 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/storage)
+"cqp" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/structure/cable,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "cqA" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 8
@@ -27164,7 +27211,7 @@
 "dOi" = (
 /obj/machinery/door/window/westleft{
 	name = "Monkey Pen";
-	req_access_txt = "9"
+	req_one_access_txt = "9;40"
 	},
 /turf/open/floor/grass,
 /area/medical/genetics)
@@ -27665,6 +27712,10 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
+"etf" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "etK" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -28806,6 +28857,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
+"fYi" = (
+/obj/structure/closet/emcloset/anchored,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "fYs" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance/four,
@@ -28917,6 +28972,11 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"gfJ" = (
+/obj/machinery/suit_storage_unit/engine,
+/obj/structure/cable,
+/turf/open/floor/plasteel/dark,
+/area/engine/engine_smes)
 "gfQ" = (
 /turf/open/space/basic,
 /area/space)
@@ -29026,6 +29086,13 @@
 	},
 /turf/open/floor/plating,
 /area/engine/atmos)
+"gts" = (
+/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
+	dir = 1
+	},
+/obj/machinery/meter,
+/turf/open/floor/engine,
+/area/engine/engineering)
 "gtz" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -29130,6 +29197,7 @@
 	name = "Power Storage";
 	req_access_txt = "11"
 	},
+/obj/structure/cable/layer1,
 /obj/structure/cable,
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
@@ -29994,6 +30062,11 @@
 /obj/structure/chair/stool,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"hFQ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable/layer1,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "hGp" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -30631,6 +30704,12 @@
 	},
 /turf/closed/wall,
 /area/science/research)
+"iJf" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "iJq" = (
 /obj/structure/closet/secure_closet/CMO,
 /obj/effect/turf_decal/tile/blue{
@@ -30679,6 +30758,13 @@
 /obj/structure/closet/secure_closet/atmospherics,
 /turf/open/floor/plasteel/showroomfloor,
 /area/engine/atmos)
+"iMR" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable/layer1,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "iNs" = (
 /mob/living/simple_animal/cockroach,
 /turf/open/floor/plating,
@@ -31079,6 +31165,11 @@
 /obj/effect/spawner/lootdrop/maintenance/four,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"jyy" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/obj/machinery/meter,
+/turf/open/floor/engine,
+/area/engine/engineering)
 "jyK" = (
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/storage)
@@ -32426,7 +32517,7 @@
 	id = "engsm";
 	name = "Radiation Chamber Shutters"
 	},
-/obj/structure/cable,
+/obj/structure/cable/layer1,
 /turf/open/floor/plating,
 /area/engine/supermatter)
 "ltM" = (
@@ -32940,7 +33031,8 @@
 /obj/machinery/power/terminal{
 	dir = 4
 	},
-/obj/structure/cable,
+/obj/structure/cable/layer1,
+/obj/structure/cable_bridge,
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
 "mpc" = (
@@ -33947,7 +34039,7 @@
 /obj/structure/cable,
 /obj/machinery/door/airlock/maintenance{
 	name = "Medbay Maintenance";
-	req_access_txt = "5"
+	req_one_access_txt = "5;9"
 	},
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
@@ -34043,7 +34135,7 @@
 "nPX" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/light,
-/obj/structure/cable,
+/obj/structure/cable/layer1,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "nQm" = (
@@ -34134,6 +34226,16 @@
 "nSF" = (
 /turf/open/floor/carpet/cyan,
 /area/hallway/primary/port)
+"nTj" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "nTk" = (
 /obj/machinery/ore_silo,
 /turf/open/floor/vault,
@@ -34304,6 +34406,20 @@
 "ogz" = (
 /turf/open/floor/plasteel/white,
 /area/security/prison)
+"ohy" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "ohz" = (
 /obj/machinery/door/window/southleft{
 	dir = 8;
@@ -35115,7 +35231,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "pwf" = (
-/obj/structure/cable,
+/obj/structure/cable/layer1,
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
 "pwC" = (
@@ -36853,6 +36969,10 @@
 /obj/item/storage/firstaid/fire,
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
+"sdI" = (
+/obj/effect/landmark/start/station_engineer,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "seQ" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -37096,6 +37216,13 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
+"szf" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 8
+	},
+/obj/structure/cable/layer1,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "szm" = (
 /obj/structure/table,
 /obj/item/stack/sheet/metal/fifty,
@@ -38431,7 +38558,6 @@
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 4
 	},
-/obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 4
@@ -38837,10 +38963,6 @@
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"uSo" = (
-/obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "uUg" = (
 /obj/machinery/door/airlock/external{
 	name = "Construction Zone"
@@ -39343,7 +39465,6 @@
 	name = "Chief Engineer";
 	req_access_txt = "56"
 	},
-/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/chief)
 "vML" = (
@@ -39429,7 +39550,8 @@
 /obj/machinery/power/terminal{
 	dir = 4
 	},
-/obj/structure/cable,
+/obj/structure/cable/layer1,
+/obj/structure/cable_bridge,
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
 "vUx" = (
@@ -39658,7 +39780,7 @@
 /area/maintenance/central)
 "wqb" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/structure/cable,
+/obj/structure/cable/layer1,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "wqO" = (
@@ -40225,6 +40347,19 @@
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/port/aft)
+"xaC" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "xbl" = (
 /obj/effect/spawner/structure/window,
 /obj/structure/cable,
@@ -40449,7 +40584,7 @@
 /obj/effect/turf_decal/stripes{
 	dir = 1
 	},
-/obj/structure/cable,
+/obj/structure/cable/layer1,
 /turf/open/floor/engine,
 /area/engine/supermatter)
 "xtK" = (
@@ -40514,6 +40649,12 @@
 /obj/item/beacon,
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
+"xzE" = (
+/obj/structure/cable,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/engine/engineering)
 "xzY" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
@@ -40712,6 +40853,10 @@
 /mob/living/simple_animal/cockroach,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"xKY" = (
+/obj/structure/closet/emcloset/anchored,
+/turf/open/floor/plasteel/showroomfloor,
+/area/tcommsat/computer)
 "xLw" = (
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/airalarm/mixingchamber{
@@ -40798,6 +40943,10 @@
 "xRd" = (
 /turf/open/floor/plasteel,
 /area/security/brig)
+"xRI" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/turf/open/floor/plating,
+/area/engine/engineering)
 "xSz" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -40820,6 +40969,10 @@
 /obj/item/storage/firstaid/regular,
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
+"xUm" = (
+/obj/structure/cable/layer1,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "xUo" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
@@ -49928,8 +50081,8 @@ jlV
 eif
 akP
 aYZ
-aZj
-aZj
+jyy
+bTT
 aZo
 aZj
 aYK
@@ -50186,7 +50339,7 @@ aJw
 aTp
 aUQ
 aVN
-aVN
+nTj
 avb
 ePQ
 bPo
@@ -50442,8 +50595,8 @@ jlV
 aJx
 aTP
 aZc
-uVd
-uVd
+iJf
+etf
 fng
 xAc
 duS
@@ -50966,7 +51119,7 @@ xAc
 xAc
 xAc
 bay
-aZE
+gts
 aYU
 aZH
 aZN
@@ -51468,7 +51621,7 @@ pVl
 qRp
 pVl
 aJx
-aTP
+bKm
 aZh
 ltr
 xtt
@@ -52020,7 +52173,7 @@ aTH
 aTH
 baV
 fLc
-fLc
+fYi
 bnA
 gfQ
 gfQ
@@ -52759,7 +52912,7 @@ pVl
 sps
 sps
 sps
-sps
+xRI
 sps
 sps
 sps
@@ -53268,7 +53421,7 @@ gOB
 lFk
 jad
 auA
-auY
+szf
 qcp
 sps
 xDz
@@ -53278,7 +53431,7 @@ iEq
 pvc
 sps
 ayu
-uSo
+xUm
 awC
 aeM
 pVl
@@ -53525,8 +53678,8 @@ ato
 aup
 auu
 auB
-auY
-akK
+szf
+sdI
 sps
 kXE
 iEq
@@ -53534,8 +53687,8 @@ oHn
 iEq
 kXE
 sps
-ayv
-uSo
+awe
+xUm
 awC
 dTp
 pVl
@@ -53781,18 +53934,18 @@ auh
 atO
 auq
 auv
-auC
+ohy
 auZ
 avc
 qqL
 kXE
-oHn
-iEq
-iEq
+xzE
 kXE
-qqL
-awg
-uVd
+kXE
+kXE
+bCo
+awe
+xUm
 ayE
 jAG
 pVl
@@ -54049,7 +54202,7 @@ oHn
 eCi
 pVl
 iPs
-uVd
+xUm
 awC
 rbm
 pVl
@@ -54295,8 +54448,8 @@ auj
 cDS
 png
 yiI
-auA
-uVd
+xaC
+xUm
 avf
 pVl
 xDz
@@ -54552,8 +54705,8 @@ ydp
 xAV
 xAV
 yiI
-auA
-uVd
+xaC
+xUm
 avg
 vOD
 pVl
@@ -54563,7 +54716,7 @@ bJy
 pVl
 vOD
 ayw
-auu
+hFQ
 hhL
 ydT
 fGE
@@ -54809,8 +54962,8 @@ xha
 mNg
 aur
 vMh
-auB
-uVd
+cqp
+xUm
 avh
 unh
 cMo
@@ -54819,8 +54972,8 @@ hKE
 drZ
 gyv
 wQP
-awe
-uVd
+iMR
+xUm
 awC
 uZK
 pVl
@@ -55067,7 +55220,7 @@ aun
 aus
 yiI
 auE
-auu
+hFQ
 avi
 avx
 avE
@@ -55618,7 +55771,7 @@ suV
 fLc
 fLc
 fLc
-fLc
+fYi
 bnA
 gfQ
 gfQ
@@ -56098,7 +56251,7 @@ bfk
 uVd
 avk
 kPn
-dbF
+gfJ
 avM
 pwf
 avX
@@ -77466,7 +77619,7 @@ fsz
 ozC
 aSt
 aSF
-hoV
+xKY
 ozC
 gfQ
 gfQ
@@ -82092,7 +82245,7 @@ gfQ
 ozC
 aSz
 aSH
-hoV
+xKY
 ozC
 gfQ
 gfQ


### PR DESCRIPTION
## About The Pull Request

Fixes genetics access.

SM fixes:

1. Switched filters to critical to prevent the area from losing power during outage events
2. Made the first filter default to filtering N2
3. Made the powernet for the rad collectors set to layer 3 and colored red to make the distinction obvious
4. Switched the emitters to draw from the station powernet to guarantee they are powered